### PR TITLE
Update accuweather.py

### DIFF
--- a/services/accuweather.py
+++ b/services/accuweather.py
@@ -9,8 +9,8 @@ import os
 
 data = [
     "http://www.accuweather.com", # url
-    "http://www.accuweather.com/vi/<b>za/sun-city/306096</b>/weather-forecast/306096", # example
-    "<b>za/sun-city/306096</b>\n"+_("If the city code is wrong, please read")+" <a href='https://github.com/RingOV/gis-weather/wiki/How-to:-AccuWeather-city-code'>How to: AccuWeather city code</a>", #code
+    "http://www.accuweather.com/en/<b>us/new-york-ny/10017</b>/weather-forecast/<b>349727</b>", # example
+    "<b>us/new-york-ny/10017,349727</b>\n"+_("If the city code is wrong, please read")+" <a href='https://github.com/RingOV/gis-weather/wiki/How-to:-AccuWeather-city-code'>How to: AccuWeather city code</a>", #code
     { 
     'en': 'English',
     'es': 'Español',


### PR DESCRIPTION
Using both numbers, even when both numbers are the same, always works. However, it took me a few minutes to realize why it wasn't working for me. This change should help people realize their mistake without having to read additional documentation. 

PS: I don't live in NY & don't care where the example is. Was just a well known place that has two different numbers.
